### PR TITLE
Logger exception before error handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.3.3 (2017-02-16)
+------------------
+
+* Add a logger.exception to message dispatcher before calling Route.error_handler
+
 0.3.2 (2016-11-14)
 ------------------
 

--- a/loafer/dispatcher.py
+++ b/loafer/dispatcher.py
@@ -59,6 +59,7 @@ class LoaferDispatcher(object):
                 logger.warning(msg.format(route.message_handler, message))
                 return False
             except Exception as exc:
+                logger.exception(exc)
                 return route.error_handler(content, exc)
 
         return True


### PR DESCRIPTION
Quando foi adicionada a opção de configurar um error_handler no route foi removido esse log, assim as exceptions não aparecem nos logs de serviços que usarem o error_handler