### PR TITLE
Fix AWS client stop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,10 @@
+3.0.7 (2021-08-24)
+------------------
+
+* Fix error on SQS provider shutdown
+
 3.0.6 (2021-08-24)
+------------------
 
 * Fix aiobotocore compatibility
 

--- a/loafer/ext/aws/bases.py
+++ b/loafer/ext/aws/bases.py
@@ -24,11 +24,6 @@ class _BotoClient:
         session = get_session()
         return session.create_client(self.boto_service_name, **self._client_options)
 
-    async def stop(self):
-        async with self.get_client() as client:
-            logger.info(f"closing client{client}")
-            await client.close()
-
 
 class BaseSQSClient(_BotoClient):
     boto_service_name = "sqs"

--- a/loafer/ext/aws/providers.py
+++ b/loafer/ext/aws/providers.py
@@ -1,10 +1,9 @@
-import asyncio
 import logging
 
 import botocore.exceptions
 
 from .bases import BaseSQSClient
-from loafer.exceptions import ProviderError, ProviderRuntimeError
+from loafer.exceptions import ProviderError
 from loafer.providers import AbstractProvider
 from loafer.utils import calculate_backoff_multiplier
 
@@ -73,15 +72,6 @@ class SQSProvider(AbstractProvider, BaseSQSClient):
 
         return response.get("Messages", [])
 
-    async def _client_stop(self):
-        async with self.get_client() as client:
-            await client.close()
-
     def stop(self):
         logger.info(f"stopping {self}")
-        loop = asyncio.get_event_loop()
-        try:
-            loop.run_until_complete(self._client_stop())
-        except RuntimeError as exc:
-            raise ProviderRuntimeError() from exc
         return super().stop()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aiobotocore"
-version = "1.4.0"
+version = "1.4.1"
 description = "Async client for aws services using botocore and aiohttp"
 category = "main"
 optional = false
@@ -147,7 +147,7 @@ python-versions = "*"
 
 [[package]]
 name = "cfgv"
-version = "3.3.0"
+version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
 category = "dev"
 optional = false
@@ -240,7 +240,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.6.4"
+version = "4.8.1"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -312,21 +312,22 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 
 [[package]]
 name = "pluggy"
-version = "0.13.1"
+version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.14.0"
+version = "2.14.1"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -359,7 +360,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.2.4"
+version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -372,7 +373,7 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0.0a1"
+pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 toml = "*"
 
@@ -489,7 +490,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
+version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
@@ -568,7 +569,7 @@ content-hash = "838a990274dace84ffb17c9325f6e1aa28afd91460bf0cf8cdd2f7223152e019
 
 [metadata.files]
 aiobotocore = [
-    {file = "aiobotocore-1.4.0.tar.gz", hash = "sha256:b61d7fbad0014f64bf6d24c272d8aaf7560178b147e36beebe7e9ee889fde216"},
+    {file = "aiobotocore-1.4.1.tar.gz", hash = "sha256:09f06723d1d69c6d407d9a356ca65ab42a5b7b73a45be4b1ed0ed1a6b6057a9f"},
 ]
 aiohttp = [
     {file = "aiohttp-3.7.4.post0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:3cf75f7cdc2397ed4442594b935a11ed5569961333d49b7539ea741be2cc79d5"},
@@ -650,8 +651,8 @@ certifi = [
     {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
 ]
 cfgv = [
-    {file = "cfgv-3.3.0-py2.py3-none-any.whl", hash = "sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1"},
-    {file = "cfgv-3.3.0.tar.gz", hash = "sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1"},
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
@@ -741,8 +742,8 @@ idna = [
     {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.6.4-py3-none-any.whl", hash = "sha256:ed5157fef23a4bc4594615a0dd8eba94b2bb36bf2a343fa3d8bb2fa0a62a99d5"},
-    {file = "importlib_metadata-4.6.4.tar.gz", hash = "sha256:7b30a78db2922d78a6f47fb30683156a14f3c6aa5cc23f77cc8967e9ab2d002f"},
+    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
+    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -804,12 +805,12 @@ platformdirs = [
     {file = "platformdirs-2.2.0.tar.gz", hash = "sha256:632daad3ab546bd8e6af0537d09805cec458dce201bccfe23012df73332e181e"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.14.0-py2.py3-none-any.whl", hash = "sha256:ec3045ae62e1aa2eecfb8e86fa3025c2e3698f77394ef8d2011ce0aedd85b2d4"},
-    {file = "pre_commit-2.14.0.tar.gz", hash = "sha256:2386eeb4cf6633712c7cc9ede83684d53c8cafca6b59f79c738098b51c6d206c"},
+    {file = "pre_commit-2.14.1-py2.py3-none-any.whl", hash = "sha256:a22d12a02da4d8df314187dfe7a61bda6291d57992060522feed30c8cd658b68"},
+    {file = "pre_commit-2.14.1.tar.gz", hash = "sha256:7977a3103927932d4823178cbe4719ab55bb336f42a9f3bb2776cff99007a117"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -820,8 +821,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
-    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.15.1.tar.gz", hash = "sha256:2564ceb9612bbd560d19ca4b41347b54e7835c2f792c504f698e05395ed63f6f"},
@@ -887,9 +888,9 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ addopts = "-vv --cov=loafer --cov-report=term-missing"
 
 [tool.poetry]
 name = "olist-loafer"
-version = "3.0.6"
+version = "3.0.7"
 description = "Asynchronous message dispatcher for concurrent tasks processing"
 license = "MIT"
 authors = ["Olist <developers@olist.com>"]

--- a/tests/ext/aws/test_bases.py
+++ b/tests/ext/aws/test_bases.py
@@ -42,13 +42,6 @@ async def test_get_queue_url_when_queue_name_is_url(mock_boto_session_sqs, boto_
 
 
 @pytest.mark.asyncio
-async def test_sqs_close(mock_boto_session_sqs, base_sqs_client, boto_client_sqs):
-    with mock_boto_session_sqs:
-        await base_sqs_client.stop()
-        boto_client_sqs.close.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_sqs_get_client(mock_boto_session_sqs, base_sqs_client, boto_client_sqs):
     with mock_boto_session_sqs as mock_session:
         client_generator = base_sqs_client.get_client()
@@ -72,13 +65,6 @@ async def test_get_topic_arn_using_topic_name(base_sns_client):
 async def test_cache_get_topic_arn_with_arn(base_sns_client):
     arn = await base_sns_client.get_topic_arn("arn:aws:sns:whatever:topic-name")
     assert arn == "arn:aws:sns:whatever:topic-name"
-
-
-@pytest.mark.asyncio
-async def test_sns_close(mock_boto_session_sns, base_sns_client, boto_client_sns):
-    with mock_boto_session_sns:
-        await base_sns_client.stop()
-        boto_client_sns.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/ext/aws/test_providers.py
+++ b/tests/ext/aws/test_providers.py
@@ -1,10 +1,9 @@
 from unittest import mock
 
 import pytest
-from asynctest import CoroutineMock
 from botocore.exceptions import BotoCoreError, ClientError
 
-from loafer.exceptions import ProviderError, ProviderRuntimeError
+from loafer.exceptions import ProviderError
 from loafer.ext.aws.providers import SQSProvider
 
 
@@ -104,23 +103,6 @@ async def test_fetch_messages_with_botocoreerror(mock_boto_session_sqs, boto_cli
         provider = SQSProvider("queue-name")
         with pytest.raises(ProviderError):
             await provider.fetch_messages()
-
-
-def test_stop():
-    provider = SQSProvider("queue-name")
-    provider._client_stop = CoroutineMock()
-    provider.stop()
-    provider._client_stop.assert_awaited()
-
-
-@pytest.mark.asyncio
-def test_reraise_runtime_error_as_sqs_provider_runtime_error(mock_boto_session_sqs, boto_client_sqs):
-    with mock_boto_session_sqs:
-        provider = SQSProvider("queue-name")
-        boto_client_sqs.close.side_effect = RuntimeError()
-
-        with pytest.raises(ProviderRuntimeError):
-            provider.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Já que todos os usos dos clients da AWS estão via context manager, eles são fechados automagicamente.

Na prática, o código anterior no método `stop` instanciava um client para fechá-lo imediatamente.