### PR TITLE
perf: start processing messages sooner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+3.0.12 (2023-04-10)
+------------------
+
+* chore: replace CircleCI with Github Actions
+* perf: start processing messages as soon as a route yields then
+
 3.0.11 (2022-11-08)
 ------------------
 

--- a/loafer/dispatchers.py
+++ b/loafer/dispatchers.py
@@ -56,7 +56,9 @@ class LoaferDispatcher:
         for provider_task in asyncio.as_completed(provider_messages_tasks):
             messages, route = await provider_task
 
-            process_messages_tasks += [self._process_message(message, route) for message in messages]
+            process_messages_tasks += [
+                asyncio.create_task(self._process_message(message, route)) for message in messages
+            ]
 
         if not process_messages_tasks:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ asyncio_mode = "strict"
 
 [tool.poetry]
 name = "olist-loafer"
-version = "3.0.11"
+version = "3.0.12"
 description = "Asynchronous message dispatcher for concurrent tasks processing"
 license = "MIT"
 authors = ["Olist <developers@olist.com>"]


### PR DESCRIPTION
Do jeito que estava, as mensagens só começariam a ser processadas fora desse loop, lá na linha do `asyncio.gather`.

Agora, assim que uma rota retornar mensagens, já começo a processá-la.