### PR TITLE
refactor: use structured concurrency

### DIFF
--- a/loafer/compat.py
+++ b/loafer/compat.py
@@ -4,10 +4,12 @@ PY311 = sys.version_info >= (3, 11)
 PY312 = sys.version_info >= (3, 12)
 
 if PY311:
-    from asyncio import to_thread
+    from asyncio import TaskGroup, to_thread
 else:
     import asyncio
     import functools
+
+    from taskgroup import TaskGroup
 
     async def to_thread(func, /, *args, **kwargs):
         loop = asyncio.get_event_loop()
@@ -23,4 +25,5 @@ else:
 __all__ = [
     "to_thread",
     "iscoroutinefunction",
+    "TaskGroup",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,10 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 requires-python = ">=3.8,<3.12"
-dependencies = ["aiobotocore>=2.0.0,<3.0.0"]
+dependencies = [
+    "aiobotocore>=2.0.0,<3.0.0",
+    "taskgroup; python_version < '3.11'",
+]
 
 [project.urls]
 Download = "https://github.com/olist/olist-loafer/releases"


### PR DESCRIPTION
Use structured concurrency instead of creating arbitrary tasks