### PR TITLE
chore: add support for python 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "loafer",
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.12",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/hatch:2": {},
 		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run linters
         run: |
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: debug-statements
       - id: trailing-whitespace
@@ -28,7 +28,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: ["--exclude=docs/*", "--ignore=E501"]
@@ -44,7 +44,7 @@ repos:
       - id: python-check-mock-methods
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.11.0
     hooks:
       - id: black
 
@@ -55,7 +55,7 @@ repos:
         args: [--add-ignore=D1, -e]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ UNRELEASED
 * refactor: remove ConfigurationError exception
 * refactor: remove concurrency limit param
 * refactor: remove max threads param
+* chore: add support for Python 3.12
 
 4.0.0 (2023-07-10)
 ------------------

--- a/hatch.toml
+++ b/hatch.toml
@@ -18,4 +18,4 @@ check-fixtures = "pytest --dead-fixtures"
 test = "pytest -vv --cov=loafer --cov-report=term-missing"
 
 [[envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Distributed Computing",
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8"
 dependencies = ["aiobotocore>=2.0.0,<3.0.0"]
 
 [project.urls]
@@ -33,7 +34,7 @@ Repository = "https://github.com/olist/olist-loafer/"
 
 [tool.black]
 line-length = 110
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
aiohttp is working on their 3.12 release: aio-libs/aiohttp#7675