### PR TITLE
refactor: task dispatching

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: ["--exclude=docs/*", "--ignore=E501"]
@@ -44,7 +44,7 @@ repos:
       - id: python-check-mock-methods
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
 
@@ -55,7 +55,7 @@ repos:
         args: [--add-ignore=D1, -e]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.14.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ UNRELEASED
 * refactor: remove ConfigurationError exception
 * refactor: remove concurrency limit param
 * refactor: remove max threads param
+* refactor: improve the task dispatching algorithm
 
 4.0.0 (2023-07-10)
 ------------------

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -123,10 +123,10 @@ async def test_message_processing_unsuccessfully(route):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_provider(route):
+async def test_dispatch_providers(route):
     route.provider.fetch_messages = mock.AsyncMock(return_value=["message"])
     dispatcher = LoaferDispatcher([route])
-    await dispatcher._dispatch_provider(route, forever=False)
+    await dispatcher.dispatch_providers(forever=False)
 
     assert route.provider.fetch_messages.called
     assert route.provider.confirm_message.called
@@ -134,23 +134,14 @@ async def test_dispatch_provider(route):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_without_tasks(route, event_loop):
+async def test_dispatch_without_tasks(route):
     route.provider.fetch_messages = mock.AsyncMock(return_value=[])
     dispatcher = LoaferDispatcher([route])
-    await dispatcher._dispatch_provider(route, forever=False)
+    await dispatcher.dispatch_providers(forever=False)
 
     assert route.provider.fetch_messages.called
     assert route.provider.confirm_message.called is False
     assert route.provider.message_not_processed.called is False
-
-
-@pytest.mark.asyncio
-async def test_dispatch_providers(route, event_loop):
-    dispatcher = LoaferDispatcher([route])
-    dispatcher._dispatch_provider = mock.AsyncMock()
-    await dispatcher.dispatch_providers(forever=False)
-
-    dispatcher._dispatch_provider.assert_called_once_with(route, False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Combina a simplicidade e uso de recursos do dispatcher da versão 3, com a velocidade do dispatcher da versão 4.

Em vez de disparar várias tasks eternas, tenho uma task principal, que mantém uma lista de tasks rodando. Isso deve simplificar um pouco, sem sacrificar muito a velocidade de processamento. Também (e é só uma teoria) deve otimizar um pouco o uso de recursos, já que só tenho um ponto onde disparo as mensagens para as rotas, e espero elas terminarem antes de puxar mais mensagens.