### PR TITLE
refactor: replace ensure_coroutinefunction with asyncio-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,10 @@ classifiers = [
   "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-  "aiobotocore>=2.0.0,<3.0.0",
-  "types-aiobotocore[sqs,sns]>=2.0.0,<3.0.0",
-  "typing-extensions; python_version < '3.12'",
+  "asyncio-extensions (>=0.0.4)",
+  "aiobotocore (~=2.0)",
+  "types-aiobotocore[sqs,sns] (~=2.0)",
+  "typing-extensions (>=4.0); python_version < '3.12'",
 ]
 dynamic = ["version"]
 

--- a/src/loafer/_compat.py
+++ b/src/loafer/_compat.py
@@ -1,33 +1,7 @@
-import asyncio
-import inspect
 import logging
 import sys
-from collections.abc import Awaitable, Callable
-from functools import partial
-from typing import ParamSpec, TypeVar, overload
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-
-
-@overload
-def ensure_coroutinefunction(func: Callable[_P, _R]) -> Callable[_P, Awaitable[_R]]: ...
-
-
-@overload
-def ensure_coroutinefunction(func: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]: ...
-
-
-def ensure_coroutinefunction(func: Callable[_P, _R] | Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
-    if inspect.iscoroutinefunction(func):
-        logger.debug("handler is coroutine! %r", func)
-        return func
-
-    logger.debug("handler will run in a separate thread: %r", func)
-    return partial(asyncio.to_thread, func)  # type: ignore[return-value]
 
 
 if sys.version_info >= (3, 12):
@@ -43,6 +17,5 @@ else:
 
 __all__ = [
     "deprecated",
-    "ensure_coroutinefunction",
     "override",
 ]

--- a/src/loafer/routes.py
+++ b/src/loafer/routes.py
@@ -1,7 +1,8 @@
 import logging
 from typing import Any
 
-from ._compat import ensure_coroutinefunction
+from asyncio_extensions import asyncify
+
 from .message_translators import AbstractMessageTranslator
 from .providers import AbstractProvider
 from .types import (
@@ -46,17 +47,17 @@ class Route:
             raise TypeError(msg)
 
         if error_handler:
-            self._error_handler: AsyncErrorHandler | None = ensure_coroutinefunction(error_handler)
+            self._error_handler: AsyncErrorHandler | None = asyncify(error_handler)
         else:
             self._error_handler = None
 
         self.handler: AsyncHandlerFunc
         self._handler_instance: Handler | None
         if callable(handler):
-            self.handler = ensure_coroutinefunction(handler)
+            self.handler = asyncify(handler)
             self._handler_instance = None
         elif isinstance(handler, Handler):
-            self.handler = ensure_coroutinefunction(handler.handle)
+            self.handler = asyncify(handler.handle)
             self._handler_instance = handler
         else:
             msg = f"handler must be a callable object or implement `handle` method: {handler!r}"


### PR DESCRIPTION
Remove the local `ensure_coroutinefunction` helper from `_compat.py` and replace all usages in `routes.py` with `asyncify` from the new `asyncio-extensions` dependency.